### PR TITLE
Fix releaser job

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -18,22 +18,18 @@ jobs:
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
-      - name: Install Dependencies
-        run: |
-          python -m pip install -e .
-
       - name: Check Release
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      # FIXME - should be done by jupyter-releaser
-      - name: Build Python package
-        run: |
-          set -ex
-          python -m pip install build
+      # # FIXME - should be done by jupyter-releaser
+      # - name: Build Python package
+      #   run: |
+      #     set -ex
+      #     python -m pip install build
 
-          python -m build
+      #     python -m build
 
       - name: Upload Distributions
         uses: actions/upload-artifact@v3
@@ -41,4 +37,3 @@ jobs:
           name: jupyter-releaser-dist-${{ github.run_number }}
           path: |
             .jupyter_releaser_checkout/dist
-            dist

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -23,14 +23,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      # # FIXME - should be done by jupyter-releaser
-      # - name: Build Python package
-      #   run: |
-      #     set -ex
-      #     python -m pip install build
-
-      #     python -m build
-
       - name: Upload Distributions
         uses: actions/upload-artifact@v3
         with:

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "build": "lerna run build",
-    "build:prod": "lerna run build:prod && lerna run clean:lib",
+    "build:prod": "lerna run build:prod",
     "build:test": "lerna run build:test",
     "clean": "lerna run clean",
     "clean:lib": "lerna run clean:lib",

--- a/package.json
+++ b/package.json
@@ -28,9 +28,10 @@
   },
   "scripts": {
     "build": "lerna run build",
-    "build:prod": "lerna run build:prod",
+    "build:prod": "lerna run build:prod && lerna run clean:lib",
     "build:test": "lerna run build:test",
     "clean": "lerna run clean",
+    "clean:lib": "lerna run clean:lib",
     "clean:all": "lerna run clean:all",
     "docs": "typedoc",
     "eslint": "jlpm eslint:check --fix",

--- a/packages/collaboration/package.json
+++ b/packages/collaboration/package.json
@@ -33,6 +33,7 @@
     "build": "tsc -b",
     "build:prod": "jlpm run build",
     "clean": "rimraf lib tsconfig.tsbuildinfo",
+    "clean:lib": "jlpm run clean:all",
     "clean:all": "rimraf lib tsconfig.tsbuildinfo node_modules",
     "install:extension": "jlpm run build",
     "watch": "tsc -b --watch"
@@ -51,7 +52,6 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
     "typescript": "~4.7.3"
   },
   "publishConfig": {

--- a/packages/docprovider/package.json
+++ b/packages/docprovider/package.json
@@ -31,6 +31,7 @@
     "build:prod": "jlpm run build",
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib tsconfig.tsbuildinfo",
+    "clean:lib": "jlpm run clean:all",
     "clean:all": "rimraf lib tsconfig.tsbuildinfo node_modules",
     "install:extension": "jlpm run build",
     "test": "jest",
@@ -54,7 +55,6 @@
     "@jupyterlab/testing": "^4.0.0-alpha.18",
     "@types/jest": "^29.2.0",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
     "typescript": "~4.7.3"
   },
   "publishConfig": {

--- a/packages/rtc-extension/package.json
+++ b/packages/rtc-extension/package.json
@@ -43,9 +43,9 @@
     "build:labextension": "jupyter labextension build .",
     "build:labextension:dev": "jupyter labextension build --development True .",
     "clean": "jlpm run clean:lib",
-    "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
+    "clean:lib": "rimraf lib tsconfig.tsbuildinfo node_modules",
     "clean:labextension": "rimraf ../../jupyterlab_rtc/labextension",
-    "clean:all": "jlpm run clean:lib && rimraf node_modules && jlpm run clean:labextension",
+    "clean:all": "jlpm run clean:lib && jlpm run clean:labextension",
     "install:extension": "jlpm run build",
     "watch": "run-p watch:src watch:labextension",
     "watch:src": "tsc -w",
@@ -73,7 +73,6 @@
     "@types/react": "^18.0.27",
     "npm-run-all": "^4.1.5",
     "rimraf": "~3.0.0",
-    "typedoc": "~0.22.10",
     "typescript": "~4.7.3"
   },
   "publishConfig": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,11 @@ before-build-npm = [
     "jlpm build:prod"
 ]
 before-build-python = [
-    "jlpm clean:all"
+    "jlpm clean:all",
+    # Build the assets
+    "jlpm build:prod",
+    # Clean the build artifacts to not include them in sdist
+    "jlpm clean:lib"
 ]
 before-bump-version = [
     "python -m pip install --pre -U jupyterlab",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,15 +27,15 @@ dependencies = [
     "jupyter_server>=2.0.0,<3.0.0",
     "jupyter_ydoc>=0.3.0,<0.4.0",
     "ypy-websocket>=0.8.2,<0.9.0",
-    "jupyter_server_fileid >=0.6.0,<1"
+    "jupyter_server_fileid>=0.6.0,<1"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 
 [project.optional-dependencies]
 dev = [
-    'click',
+    "click",
     "pre-commit",
-    'jupyter_releaser'
+    "jupyter_releaser"
 ]
 test = [
     "coverage",
@@ -94,13 +94,7 @@ build_cmd = "build:prod"
 editable_build_cmd = "install:extension"
 
 [tool.jupyter-releaser]
-skip = [
-    "check-links",
-    # FIXME
-    "check-npm",
-    "build-python",
-    "check-python"
-]
+skip = ["check-links"]
 
 [tool.jupyter-releaser.options]
 version-cmd = "python scripts/bump_version.py --force"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ fields = ["description", "authors", "urls"]
 
 [tool.hatch.build.targets.sdist]
 artifacts = ["/jupyterlab_rtc/labextension"]
-exclude = ["/.github", "/binder"]
+exclude = ["/.github", "/binder", "node_modules"]
 
 [tool.hatch.build.targets.sdist.force-include]
 "./packages" = "packages"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5648,7 +5648,7 @@ glob@^7.1.3, glob@^7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^8.0.1, glob@^8.0.3:
+glob@^8.0.1:
   version "8.1.0"
   resolved "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz"
   integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
@@ -6874,7 +6874,7 @@ json5@^2.1.2, json5@^2.2.2, json5@^2.2.3:
   resolved "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsonc-parser@3.2.0, jsonc-parser@^3.0.0, jsonc-parser@^3.2.0:
+jsonc-parser@3.2.0, jsonc-parser@^3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz"
   integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
@@ -7310,7 +7310,7 @@ map-obj@^4.0.0:
   resolved "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz"
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
 
-marked@^4.0.16, marked@^4.2.5:
+marked@^4.2.5:
   version "4.2.12"
   resolved "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz"
   integrity sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==
@@ -7426,7 +7426,7 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1, minimatch@^5.1.0, minimatch@^5.1.2:
+minimatch@^5.0.1, minimatch@^5.1.2:
   version "5.1.6"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz"
   integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
@@ -8930,15 +8930,6 @@ shell-quote@^1.6.1:
   resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.0.tgz"
   integrity sha512-QHsz8GgQIGKlRi24yFc6a6lN69Idnx634w49ay6+jA5yFh7a1UY+4Rp6HPx/L/1zcEDPEij8cIsiqR6bQsE5VQ==
 
-shiki@^0.10.1:
-  version "0.10.1"
-  resolved "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz"
-  integrity sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==
-  dependencies:
-    jsonc-parser "^3.0.0"
-    vscode-oniguruma "^1.6.1"
-    vscode-textmate "5.2.0"
-
 shiki@^0.12.1:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.12.1.tgz#26fce51da12d055f479a091a5307470786f300cd"
@@ -9651,17 +9642,6 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typedoc@~0.22.10:
-  version "0.22.18"
-  resolved "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz"
-  integrity sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==
-  dependencies:
-    glob "^8.0.3"
-    lunr "^2.3.9"
-    marked "^4.0.16"
-    minimatch "^5.1.0"
-    shiki "^0.10.1"
-
 typedoc@~0.23.24:
   version "0.23.24"
   resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.23.24.tgz#01cf32c09f2c19362e72a9ce1552d6e5b48c4fef"
@@ -9861,15 +9841,10 @@ validate.io-number@^1.0.3:
   resolved "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz"
   integrity sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg==
 
-vscode-oniguruma@^1.6.1, vscode-oniguruma@^1.7.0:
+vscode-oniguruma@^1.7.0:
   version "1.7.0"
   resolved "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz"
   integrity sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==
-
-vscode-textmate@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz"
-  integrity sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==
 
 vscode-textmate@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION
This fixes the jupyter releaser job. Actually the culprit was the installation package step.

Configuration to include the `packages` files in sdist without the transient build files is a bit tricky. The final solution is to call `clean:lib` after `build:prod` in the build python step.