### PR TITLE
Drop pytest_tornasync

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,9 +41,7 @@ test = [
     "coverage",
     "jupyter_server[test]>=2.0.0",
     "pytest>=7.0",
-    "pytest_tornasync",
     "pytest-cov",
-    "pytest-timeout",
 ]
 docs = [
     "jupyterlab>=4.0.0a32",


### PR DESCRIPTION
Fixes #74

Drop unused `pytest_tornasync`